### PR TITLE
Add inline pipe a replacement for standard lib pipe

### DIFF
--- a/core/src/main/scala/extensions.scala
+++ b/core/src/main/scala/extensions.scala
@@ -39,6 +39,10 @@ object extensions:
     def pps: A                             = kCombinator(x => pprintln(x.toString))
     infix def pp(msg: String): A           = kCombinator(x => pprintlnBoth(msg, x))
 
+    // copy from: https://github.com/Ichoran/kse3/blob/d3e3ec4771599204a22091ece804dd3491b31ea3/basics/src/Data.scala#L5506C1-L5507C49
+    /** replacement for standard lib pipe use inline to avoid boxing */
+    inline def pipe[B](inline f: A => B): B = f(a)
+
   extension [A, B](m: Map[A, B])
     // Add Map.mapKeys, similar to Map.mapValues
     def mapKeys[C](f: A => C): Map[C, B] = m.map { (a, b) => (f(a), b) }


### PR DESCRIPTION
This is more performance as it doesn't required an extra allocation

Code copy from https://github.com/Ichoran/kse3/blob/d3e3ec4771599204a22091ece804dd3491b31ea3/basics/src/Data.scala#L5506C1-L5507C49

Which also has some other good stuff.