### PR TITLE
Add transform for SameRunTime trait

### DIFF
--- a/core/src/main/scala/newtypes.scala
+++ b/core/src/main/scala/newtypes.scala
@@ -13,6 +13,8 @@ object newtypes:
   trait SameRuntime[A, T]:
     def apply(a: A): T
 
+    extension (a: A) def transform: T = apply(a)
+
   object SameRuntime:
     def apply[A, T](f: A => T): SameRuntime[A, T] = new:
       def apply(a: A): T = f(a)


### PR DESCRIPTION
With this We can have a better ergonomic code with implicit context, which We use exclusively for SameRuntime in lila. for example, with this PR We can refactor as follow:

```diff
   extension [A](m: Mapping[A])
-    def into[B](using sr: SameRuntime[A, B], rs: SameRuntime[B, A]): Mapping[B] =
-      m.transform(sr.apply, rs.apply)
+    def into[B](using SameRuntime[A, B], SameRuntime[B, A]): Mapping[B] =
+      m.transform(_.transform, _.transform)
```

(Refactor for https://github.com/lichess-org/lila/blob/master/modules/common/src/main/Form.scala#L287-L289)