### PR TITLE
Add Future.discard extension method

### DIFF
--- a/lila/src/main/scala/future.scala
+++ b/lila/src/main/scala/future.scala
@@ -33,6 +33,8 @@ object extensions:
     inline def void: Future[Unit] =
       fua.dmap(_ => ())
 
+    inline def discard: Unit = ()
+
     inline infix def inject[B](b: => B): Future[B] =
       fua.dmap(_ => b)
 


### PR DESCRIPTION
This method can be used to mark Future values that we're explicitly ignoring, to enable better unused value detection.