### PR TITLE
Update time.nowNanos()

### DIFF
--- a/core/src/main/scala/time.scala
+++ b/core/src/main/scala/time.scala
@@ -78,11 +78,16 @@ object time:
 
   inline def nowDateTime: LocalDateTime = LocalDateTime.now()
   inline def nowInstant: Instant        = Instant.now()
-  inline def nowNanos: Long             = System.nanoTime()
   inline def nowMillis: Long            = System.currentTimeMillis()
   inline def nowCentis: Long            = nowMillis / 10
   inline def nowTenths: Long            = nowMillis / 100
   inline def nowSeconds: Int            = (nowMillis / 1000).toInt
+
+  /** Relative to some arbitrary point in time.
+    *
+    * Useful only in comparisons to self, such as measuring time intervals.
+    */
+  inline def nowNanosRel: Long = System.nanoTime()
 
   def instantOf(year: Int, month: Int, dayOfMonth: Int, hour: Int, minute: Int) =
     java.time.LocalDateTime.of(year, month, dayOfMonth, hour, minute).instant


### PR DESCRIPTION
`System.nanoTime()` is relative to some point in time which changes each run. It's useful only to track elapsed nanos, not to measure a wall clock.

`nowNanos()` is not being currently being used, from what I can tell, so rename method to be less confusing.