### PR TITLE
Add OpaqueIntSafer

### DIFF
--- a/core/src/main/scala/newtypes.scala
+++ b/core/src/main/scala/newtypes.scala
@@ -52,15 +52,15 @@ object newtypes:
 
   trait OpaqueInt[A](using A =:= Int) extends TotalWrapper[A, Int]:
     extension (inline a: A)
-      inline def unary_-                          = apply(-raw(a))
+      inline def unary_- : A                      = apply(-raw(a))
       inline infix def >(inline o: Int): Boolean  = raw(a) > o
       inline infix def <(inline o: Int): Boolean  = raw(a) < o
       inline infix def >=(inline o: Int): Boolean = raw(a) >= o
       inline infix def <=(inline o: Int): Boolean = raw(a) <= o
       inline infix def +(inline o: Int): A        = apply(raw(a) + o)
       inline infix def -(inline o: Int): A        = apply(raw(a) - o)
-      inline def atLeast(inline bot: Int): A      = apply(math.max(raw(a), bot))
-      inline def atMost(inline top: Int): A       = apply(math.min(raw(a), top))
+      inline def atLeast(inline bot: Int): A      = apply(Math.max(raw(a), bot))
+      inline def atMost(inline top: Int): A       = apply(Math.min(raw(a), top))
       inline infix def >(inline o: A): Boolean    = >(raw(o))
       inline infix def <(inline o: A): Boolean    = <(raw(o))
       inline infix def >=(inline o: A): Boolean   = >=(raw(o))
@@ -69,6 +69,18 @@ object newtypes:
       inline infix def -(inline o: A): A          = a - raw(o)
       inline def atLeast(inline bot: A): A        = atLeast(raw(bot))
       inline def atMost(inline top: A): A         = atMost(raw(top))
+
+  trait OpaqueIntSafer[A](using A =:= Int) extends TotalWrapper[A, Int]:
+    extension (inline a: A)
+      inline def unary_- : A                    = apply(-raw(a))
+      inline infix def >(inline o: A): Boolean  = raw(a) > raw(o)
+      inline infix def <(inline o: A): Boolean  = raw(a) < raw(o)
+      inline infix def >=(inline o: A): Boolean = raw(a) >= raw(o)
+      inline infix def <=(inline o: A): Boolean = raw(a) <= raw(o)
+      inline infix def +(inline o: A): A        = apply(raw(a) + raw(o))
+      inline infix def -(inline o: A): A        = apply(raw(a) - raw(o))
+      inline def atLeast(inline bot: A): A      = apply(Math.max(raw(a), raw(bot)))
+      inline def atMost(inline top: A): A       = apply(Math.min(raw(a), raw(top)))
 
   trait OpaqueLong[A](using A =:= Long) extends TotalWrapper[A, Long]
   trait OpaqueDouble[A](using A =:= Double) extends TotalWrapper[A, Double]:


### PR DESCRIPTION
This OpaqueType does not allow implicit conversion of RHS operands of
    the underlying type.