### PR TITLE
Optimize TotalWrapper

### DIFF
--- a/core/src/main/scala/newtypes.scala
+++ b/core/src/main/scala/newtypes.scala
@@ -13,15 +13,14 @@ import alleycats.Zero
 //
 // Details: The classes use witnesses to ensure type compatibility.  However, in order to completely inline
 // simple methods like `<` (OpaqueInt), we cannot use the witness, and instead "cast" using asInstanceOf.
-// during compile scala3 (as of now) detects and redundant casts when using asInstanceOf, but it does *not*
-// detect or remove witness casts. So, when using asInstanceOf, types are completely elided, but not so with
-// witnesses. This is especially problematic for methods marked with `inline` which are expected to be small.
+// During compilation, scala3 detects and removes redundant casts when using asInstanceOf, but it does *not*
+// detect or remove redudant witness casts. So, when using asInstanceOf, types are completely elided, but not
+// so with witnesses. This is especially problematic for methods marked `inline` which should be small.
 //
 // The challenge for you, dear coder, when writing new code, either in this file or in a subclass, is that
-// you can accidentally rely on a witness cast, because scala will happily use a witness implicitly.
-// changing this file, it's up to you to ensure any new code does not use the witness (by using `raw`, `apply`,
-// or the extension methods).  It's still a fairly efficient operation, but if the method you write is inlined,
-// it can cause performance degredation.
+// you can accidentally rely on a witness cast, because scala will happily use a witness implicitly for
+// conversions. It's up to you to ensure any new code does not use a witness conversion (use `raw`, `apply`,
+// or extension methods instead).
 //
 // === Why this issue is not regression tested ===
 // - The scala class `=:=` is sealed and difficult/impossible to subclass, so we cannot create a mock which raises

--- a/core/src/main/scala/newtypes.scala
+++ b/core/src/main/scala/newtypes.scala
@@ -109,6 +109,9 @@ object newtypes:
   abstract class OpaqueDuration[A](using A =:= FiniteDuration) extends TotalWrapper[A, FiniteDuration]
 
   abstract class YesNo[A](using A =:= Boolean) extends TotalWrapper[A, Boolean]:
+    final val Yes: A = apply(true)
+    final val No: A  = apply(false)
+
     extension (inline a: A)
       inline def flip: A                  = apply(!raw(a))
       inline def yes: Boolean             = raw(a)

--- a/core/src/main/scala/newtypes.scala
+++ b/core/src/main/scala/newtypes.scala
@@ -71,6 +71,7 @@ object newtypes:
 
   abstract class OpaqueInt[A](using A =:= Int) extends TotalWrapper[A, Int]:
     extension (inline a: A)
+      inline def unary_- : A                      = apply(-raw(a))
       inline infix def >(inline o: Int): Boolean  = raw(a) > o
       inline infix def <(inline o: Int): Boolean  = raw(a) < o
       inline infix def >=(inline o: Int): Boolean = raw(a) >= o


### PR DESCRIPTION
Because of the use of evidence, the types for TotalWrapper are not being elided, leading to 10-15 JVM instruction methods for OpaqueInt::atMost.  This is especially problematic because these methods are tagged 'inline', so they are significantly increasing size of the methods which use OpaqueInts.

I've verified these changes now correctly elide types entirely, but this implementation is extremely fragile. Because scala sees evidence for conversion, it will implicitly use the evidence given a chance, which we don't want.

The best I could come up with is a scary warning. :-\