### PR TITLE
11.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ inThisBuild(
   Seq(
     scalaVersion  := "3.5.1",
     versionScheme := Some("early-semver"),
-    version       := "11.3.0",
+    version       := "11.3.1",
     organization  := "org.lichess",
     licenses += ("MIT" -> url("https://opensource.org/licenses/MIT")),
     publishTo     := Option(Resolver.file("file", new File(sys.props.getOrElse("publishTo", ""))))

--- a/model/src/main/scala/model.scala
+++ b/model/src/main/scala/model.scala
@@ -5,16 +5,16 @@ import scalalib.newtypes.*
 object model:
 
   opaque type Max = Int
-  object Max extends OpaqueInt[Max]
+  object Max extends RelaxedOpaqueInt[Max]
 
   opaque type MaxPerPage = Int
-  object MaxPerPage extends OpaqueInt[MaxPerPage]
+  object MaxPerPage extends RelaxedOpaqueInt[MaxPerPage]
 
   opaque type MaxPerSecond = Int
-  object MaxPerSecond extends OpaqueInt[MaxPerSecond]
+  object MaxPerSecond extends RelaxedOpaqueInt[MaxPerSecond]
 
   opaque type Days = Int
-  object Days extends OpaqueInt[Days]
+  object Days extends RelaxedOpaqueInt[Days]
 
   opaque type Seconds = Int
-  object Seconds extends OpaqueInt[Seconds]
+  object Seconds extends RelaxedOpaqueInt[Seconds]


### PR DESCRIPTION
- Remove extra definitions recently added to OpaqueX
- Rename OpaqueInt -> RelaxedOpaqueInt
- Rename OpaqueIntSafer -> RichOpaqueInt
- Rename FunctionWrapper.apply -> exec The apply method is overloaded with TotalWrapper.apply, leading to spurious build errors. And also it seems like best practice to explicitly unwrap an Opaque function if we want to use it.
- Restore trait to SameRuntime (required by FunctionalInterface tag)


Note: Currently only use of RichOpaqueInt is Centis.  Many users of OpaqueInt in lila need to be renamed to RelaxedOpaqueInt, and many users of FunctionWrapper need the 'exec' method call added.

There are related PRs in scalachess, lila-ws, and lila for the upgrade.